### PR TITLE
Support the new format of the json config

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="edu.berkeley.eecs.emission.cordova.settings"
-        version="1.0.0">
+        version="1.0.1">
 
   <name>ConnectionSettings</name>
   <description>Simple package that stores all the connection settings that need to be configured</description>

--- a/src/android/ConnectionSettings.java
+++ b/src/android/ConnectionSettings.java
@@ -77,11 +77,12 @@ public class ConnectionSettings {
         } catch (MalformedURLException e) {
             Log.exception(ctxt, TAG, e);
             e.printStackTrace();
+            return null;
         } catch (IOException e) {
             Log.exception(ctxt, TAG, e);
             e.printStackTrace();
-        }
         return null;
+    }
     }
 
     private static JSONObject getConfigFromFile(Context ctxt, InputStream configFileStream) {
@@ -139,13 +140,16 @@ public class ConnectionSettings {
         }
 	}
 
-    public static boolean isSkipAuth(Context ctxt) {
-        String connectURL = getConnectURL(ctxt);
-        if (connectURL.startsWith("http:")) {
-            System.out.println("connectURL starts with http, skipping auth");
-            return true;
-        } else {
-            return false;
+    public static String getAuthMethod(Context ctxt) {
+        if (sharedInstance(ctxt).connectionSettings == null) {
+            return null;
+        }
+        try {
+            return ConnectionSettings.nativeAuth(ctxt).getString("method");
+        } catch(JSONException e) {
+            Log.e(ctxt, TAG, "Got exception while retrieving connection settings");
+            Log.exception(ctxt, TAG, e);
+            return null;
         }
     }
 	
@@ -154,11 +158,15 @@ public class ConnectionSettings {
             return null;
         }
         try {
-            return sharedInstance(ctxt).connectionSettings.getJSONObject("android").getString("googleWebAppClientID");
+            return ConnectionSettings.nativeAuth(ctxt).getString("clientID");
         } catch(JSONException e) {
             Log.e(ctxt, TAG, "Got exception while retrieving connection settings");
             Log.exception(ctxt, TAG, e);
             return null;
 	}
 	}
+
+    private static JSONObject nativeAuth(Context ctxt) throws JSONException {
+        return sharedInstance(ctxt).connectionSettings.getJSONObject("android").getJSONObject("auth");
+    }
 }

--- a/src/ios/BEMConnectionSettings.h
+++ b/src/ios/BEMConnectionSettings.h
@@ -13,6 +13,6 @@
 +(ConnectionSettings*) sharedInstance;
 -(NSDictionary*)getSettings;
 -(NSURL*) getConnectUrl;
--(BOOL)isSkipAuth;
--(NSString*) getGoogleiOSClientID;
+-(NSString*) authMethod;
+-(NSString*) getClientID;
 @end

--- a/src/ios/BEMConnectionSettings.m
+++ b/src/ios/BEMConnectionSettings.m
@@ -61,18 +61,14 @@ static ConnectionSettings *sharedInstance;
     return [NSURL URLWithString:[connSettingDict objectForKey: @"connectUrl"]];
 }
 
-- (BOOL)isSkipAuth
+- (NSString*) authMethod
 {
-    if([[self getConnectUrl].scheme isEqualToString:@"http"]) {
-        return true;
-    } else {
-        return false;
-    }
+    return [[[connSettingDict objectForKey: @"ios"] objectForKey:@"auth"] objectForKey:@"method"];
 }
 
-- (NSString*)getGoogleiOSClientID
+- (NSString*)getClientID
 {
-    return [[connSettingDict objectForKey: @"ios"] objectForKey:@"googleClientID"];
+    return [[[connSettingDict objectForKey: @"ios"] objectForKey:@"auth"] objectForKey:@"clientID"];
 }
 
 @end

--- a/www/connectionsettings.js
+++ b/www/connectionsettings.js
@@ -8,10 +8,16 @@ var exec = require("cordova/exec")
  *    "connectUrl": "...",
  *    "isSkipAuth": true/false,
  *    "android": {
- *        "googleWebAppClientID": "...",
+ *        "auth": {
+ *            "method": "e.g. google-authutil",
+ *            "clientID": "e.g. XXXXX"
+ *        }
  *    },
  *    "ios": {
- *       "googleClientID": "...",
+ *        "auth": {
+ *            "method": "e.g. google-signin-lib",
+ *            "clientID": "e.g. YYYYY"
+ *        }
  *    }
  * }
  */

--- a/www/connectionsettings.js
+++ b/www/connectionsettings.js
@@ -22,11 +22,6 @@ var ConnectionSettings = {
     		exec(resolve, reject, "ConnectionSettings", "getSettings", []);
     	});
     }
-    setSettings: function (newConfig) {
-        return new Promise(function(resolve, reject) {
-            exec(resolve, reject, "ConnectionSettings", "setConfig", [newConfig]);
-        };
-    }
 }
 
 module.exports = ConnectionSettings;


### PR DESCRIPTION
We now have an authMethod instead of simply storing skipAuth or not, and have moved the client IDs into the platform tags.

The new format has been documented in the js interface as well
