### PR TITLE
Ensure that sane settings are returned by default

### DIFF
--- a/src/ios/BEMConnectionSettings.m
+++ b/src/ios/BEMConnectionSettings.m
@@ -32,12 +32,9 @@ static ConnectionSettings *sharedInstance;
         NSData *data = [content dataUsingEncoding:NSUTF8StringEncoding];
         connSettingDict = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:nil];
     } else {
-        UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"Error while config file"
-                                                        message:[NSString stringWithFormat:@"Config file not found at path %@", configFilePath]
-                                                       delegate:nil
-                                              cancelButtonTitle:@"OK"
-                                              otherButtonTitles:nil];
-        [alert show];
+        // Use default values optimized for dev setting
+        connSettingDict = @{@"connectUrl": @"http://localhost:8080",
+                            @"ios": @{@"auth": @{@"method": @"dummy-dev"}}};
     }
 
     return [super init];
@@ -68,6 +65,9 @@ static ConnectionSettings *sharedInstance;
 
 - (NSString*)getClientID
 {
+    if (connSettingDict == NULL) {
+        return NULL;
+    }
     return [[[connSettingDict objectForKey: @"ios"] objectForKey:@"auth"] objectForKey:@"clientID"];
 }
 


### PR DESCRIPTION
Return settings that are suitable for instant use with the emulator
`(localhost:8080, dummy-dev)` on iOS and (10.0.0.2:8080, dummy-dev) on android.
This ensures that people can start playing with the app immediately.
We can then remove the step to copy the connection settings over!