### PR TITLE
Return the connection string instead of the connection URL

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="cordova-plugin-em-settings"
-        version="1.2.2">
+        version="1.2.3">
 
   <name>ConnectionSettings</name>
   <description>Simple package that stores all the connection settings that need to be configured</description>

--- a/src/ios/BEMConnectionSettings.h
+++ b/src/ios/BEMConnectionSettings.h
@@ -14,7 +14,7 @@
 -(NSDictionary*)getSettings;
 -(NSDictionary*)getDefaultConfig;
 -(void)setSettings:(NSDictionary*)newConfig;
--(NSURL*) getConnectUrl;
+-(NSString*) getConnectString;
 -(NSString*) authMethod;
 -(NSString*) authValueForKey:(NSString*) key;
 @end

--- a/src/ios/BEMConnectionSettings.m
+++ b/src/ios/BEMConnectionSettings.m
@@ -85,7 +85,7 @@ static ConnectionSettings *sharedInstance;
 // from the plugin initialize methods before the javascript has the opportunity to set the config
 // Note that we cannot throw from the constructor instead because then we cannot create the shared instance
 // and even the javascript cannot set the config
-- (NSURL*)getConnectUrl
+- (NSString*)getConnectString
 {
     if (connSettingDict == NULL) {
         NSException* notFoundEx = [[NSException alloc] initWithName:@"SettingsNotFound"
@@ -94,7 +94,7 @@ static ConnectionSettings *sharedInstance;
         @throw notFoundEx;
     }
 
-    return [NSURL URLWithString:[connSettingDict objectForKey: @"connectUrl"]];
+    return [connSettingDict objectForKey: @"connectUrl"];
 }
 
 - (NSDictionary*) nativeAuth


### PR DESCRIPTION
This allows us to construct relative URLs by appending strings
instead of using the relative URL method, which doesn't work if the base URL is
a URL as opposed to just a hostname.

https://github.com/e-mission/e-mission-docs/issues/732#issuecomment-1140300236